### PR TITLE
[UI] Revamped: navbar menu and home page

### DIFF
--- a/components/dashboard/tabs.js
+++ b/components/dashboard/tabs.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import loadContent from '../../utils/load-content';
 
-const tabs = ['New', 'Trending', 'Releases'];
+const tabs = ['New'];
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');

--- a/components/nav/index.js
+++ b/components/nav/index.js
@@ -16,7 +16,6 @@ function Nav({ children }) {
     <div className={classNames(search && 'min-h-[5050px] xl:min-h-[3500px]', 'min-h-screen')}>
       <div className="z-50 w-full">
         <TopBar setSearch={setSearch} />
-        <NavPromotion />
       </div>
 
       <div className="min-h-full">

--- a/components/nav/nav-sidebar.js
+++ b/components/nav/nav-sidebar.js
@@ -35,18 +35,6 @@ const navigation = [
     icon: NewspaperIcon,
     disabled: false
   },
-  {
-    name: 'Bounty Board',
-    href: '/bounties',
-    icon: ClipboardCheckIcon,
-    disabled: false
-  },
-  {
-    name: 'Jobs',
-    href: '/jobs',
-    icon: BriefcaseIcon,
-    disabled: false
-  }
 ];
 
 const special = [

--- a/pages/bounties.js
+++ b/pages/bounties.js
@@ -4,7 +4,10 @@ import BountyStats from "../components/bounties/stats";
 import fetch from "../utils/fetcher";
 
 export async function getStaticProps() {
-  const companies = await fetch(
+    if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'production') {
+        return { notFound: true };
+    }
+    const companies = await fetch(
     `${process.env.NEXT_PUBLIC_API_ENDPOINT}/companies`
   );
 

--- a/pages/jobs.js
+++ b/pages/jobs.js
@@ -4,6 +4,9 @@ import fetch from "../utils/fetcher";
 import markdownToHtml from "../utils/markdown";
 
 export async function getStaticProps() {
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'production') {
+    return { notFound: true };
+  }
   const response = await fetch(
     `${process.env.NEXT_AIRTABLE_URL}`
   );


### PR DESCRIPTION
## Description
This PR removes bounty, and job sections from the navbar i.e. `URL/bounties` will show the `404` page. Pages are excluded from the build environment by using `getStaticProps`.
```
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'development') {
    return { notFound: true };
  }
 ```
Along with this, it removes the Trending, and Releases tabs and promotion banner from the home page.

## What PR does

- [x] Removes banner from the home page
- [x] Removes Trending and Releases tabs from the home page
- [x] Remove the Bounty Board section
- [x] Remove the Jobs section