### PR TITLE
feat: add final security lessons

### DIFF
--- a/course/content/arbitrary-cpi.md
+++ b/course/content/arbitrary-cpi.md
@@ -16,7 +16,7 @@
 
 # Overview
 
-A cross program invocation (CPI) is when one program invokes an instruction on another program. An “arbitrary CPI” is when a program is structured to issues a CPI to whatever program is passed into the instruction rather than expecting to perform a CPI to one specific program. Given that the callers of your program's instruction can pass any program they'd like into the instruction's list of accounts, failing to verify the address of a passed-in program results in your program performing CPIs to arbitrary programs.
+A cross program invocation (CPI) is when one program invokes an instruction on another program. An “arbitrary CPI” is when a program is structured to issue a CPI to whatever program is passed into the instruction rather than expecting to perform a CPI to one specific program. Given that the callers of your program's instruction can pass any program they'd like into the instruction's list of accounts, failing to verify the address of a passed-in program results in your program performing CPIs to arbitrary programs.
 
 This lack of program checks creates an opportunity for a malicious user to pass in a different program than expected, causing the original program to call an instruction on this mystery program. There’s no telling what the consequences of this CPI could be. It depends on the program logic (both that of the original program and the unexpected program), as well as what other accounts are passed into the original instruction.
 
@@ -157,7 +157,7 @@ use other_program::program::OtherProgram;
 
 # Demo
 
-To show the importance of checking with program you use for CPIs, we're going to work with a simplified and somewhat contrived game. This game represents characters with PDA accounts, and uses a separate "metadata" program to manage character metadata and attributes like halth and power.
+To show the importance of checking with program you use for CPIs, we're going to work with a simplified and somewhat contrived game. This game represents characters with PDA accounts, and uses a separate "metadata" program to manage character metadata and attributes like health and power.
 
 While this example is somewhat contrived, it's actually almost identical architecture to how NFTs on Solana work: the SPL Token Program manages the token mints, distribution, and transfers, and a separate metadata program is used to assign metadata to tokens. So the vulnerability we go through here could also be applied to real tokens.
 
@@ -178,7 +178,7 @@ The first program, `gameplay`, is the one that our test directly uses. Take a lo
 1. `create_character_insecure` - creates a new character and CPI's into the metadata program to set up the character's initial attributes
 2. `battle_insecure` - pits two characters against each other, assigning a "win" to the character with the highest attributes
 
-The second program, `character-metadata`, is meant to be the "approved" program for handling character metadata. Have a look at this program. It has a single instruction for `create_metadata` that creates a new PDA and assigns a pseudo-random value between 0 and 20 to for the character's health and power.
+The second program, `character-metadata`, is meant to be the "approved" program for handling character metadata. Have a look at this program. It has a single instruction for `create_metadata` that creates a new PDA and assigns a pseudo-random value between 0 and 20 for the character's health and power.
 
 The last program, `fake-metadata` is a "fake" metadata program meant to illustrate what an attacker might make to exploit our `gameplay` program. This program is almost identical to the `character-metadata` program, only it assigns a character's initial health and power to be the max allowed: 255.
 
@@ -239,7 +239,7 @@ it("Insecure instructions allow attacker to win every time", async () => {
 })
 ```
 
-This test effectively walks through the scenario where a regular play and an attacker both create their characters. Only the attacker passes in the program ID of the fake metadata program rather than the actual metadata program. And since the `create_character_insecure` instruction has no program checks, it still executes. 
+This test effectively walks through the scenario where a regular player and an attacker both create their characters. Only the attacker passes in the program ID of the fake metadata program rather than the actual metadata program. And since the `create_character_insecure` instruction has no program checks, it still executes.
 
 The result is that the regular character has the appropriate amount of health and power: each a value between 0 and 20. But the attacker's health and power are each 255, making the attacker unbeatable.
 
@@ -255,8 +255,8 @@ We'll start by updating our `use` statement at the top of the `gameplay` program
 
 ```rust
 use character_metadata::{
-    cpi::accounts::CreateMetadata, 
-    cpi::create_metadata, 
+    cpi::accounts::CreateMetadata,
+    cpi::create_metadata,
     program::CharacterMetadata,
 };
 ```

--- a/course/content/bump-seed-canonicalization.md
+++ b/course/content/bump-seed-canonicalization.md
@@ -1,0 +1,504 @@
+# Bump Seed Canonicalization
+
+# Lesson Objectives
+
+- Explain the vulnerabilities associated with using PDAs derived without the canonical bump
+- Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump
+- Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA
+
+# TL;DR
+
+- The [**`create_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) function derives a PDA without searching for the **canonical bump**. This means there are multiple valid bumps, all of which will produce different addresses.
+- Using [**`find_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address) ensures that the highest valid bump, or canonical bump, is used for the derivation, thus creating a deterministic way to find an address given specific seeds.
+- Upon initialization, you can use Anchor's `seeds` and `bump` constraint to ensure that PDA derivations in the account validation struct always use the canonical bump
+- Anchor allows you to **specify a bump** with the `bump = <some_bump>` constraint when verifying the address of a PDA
+- Because `find_program_address` can be expensive, best practice is to store the derived bump in an account’s data field to be referenced later on when re-deriving the address for verification
+    ```rust
+    #[derive(Accounts)]
+    pub struct VerifyAddress<'info> {
+    	#[account(
+        	seeds = [DATA_PDA_SEED.as_bytes()],
+    	    bump = data.bump
+    	)]
+    	data: Account<'info, Data>,
+    }
+    ```
+
+# Overview
+
+Bump seeds are a number between 0 and 255, inclusive, used to ensure that an address derived using [`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) is a valid PDA. The **canonical bump** is the highest bump value that produces a valid PDA. The standard in Solana is to *always use the canonical bump* when deriving PDAs, both for security and convenience. 
+
+## Insecure PDA derivation using `create_program_address`
+
+Given a set of seeds, the `create_program_address` function will produce a valid PDA about 50% of the time. The bump seed is an additional byte added as a seed to "bump" the derived address into valid territory. Since there are 256 possible bump seeds and the function produces valid PDAs approximately 50% of the time, there are many valid bumps for a given set of input seeds.
+
+You can imagine that this could cause confusion for locating accounts when using seeds as a way of mapping between known pieces of information to accounts. Using the canonical bump as the standard ensures that you can always find the right account. More importantly, it avoids security exploits caused by the open-ended nature of allowing multiple bumps.
+
+In the example below, the `set_value` instruction uses a `bump` that was passed in as instruction data to derive a PDA. The instruction then derives the PDA using `create_program_address` function and checks that the `address` matches the public key of the `data` account.
+
+```rust
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod bump_seed_canonicalization_insecure {
+    use super::*;
+
+    pub fn set_value(ctx: Context<BumpSeed>, key: u64, new_value: u64, bump: u8) -> Result<()> {
+        let address =
+            Pubkey::create_program_address(&[key.to_le_bytes().as_ref(), &[bump]], ctx.program_id).unwrap();
+        if address != ctx.accounts.data.key() {
+            return Err(ProgramError::InvalidArgument.into());
+        }
+
+        ctx.accounts.data.value = new_value;
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct BumpSeed<'info> {
+    data: Account<'info, Data>,
+}
+
+#[account]
+pub struct Data {
+    value: u64,
+}
+```
+
+While the instruction derives the PDA and checks the passed-in account, which is good, it allows the caller to pass in an arbitrary bump. Depending on the context of your program, this could result in undesired behavior or potential exploit.
+
+If the seed mapping was meant to enforce a one-to-one relationship between PDA and user, for example, this program would not properly enforce that. A user could call the program multiple times with many valid bumps, each producing a different PDA.
+
+## Recommended derivation using `find_program_address`
+
+A simple way around this problem is to have the program expect only the canonical bump and use `find_program_address` to derive the PDA. 
+
+The [`find_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.find_program_address) *always uses the canonical bump*. This function iterates through calling `create_program_address`, starting with a bump of 255 and decrementing the bump by one with each iteration. As soon as a valid address is found, the function returns both the derived PDA and the canonical bump used to derive it.
+
+This ensures a one-to-one mapping between your input seeds and the address they produce.
+
+```rust
+pub fn set_value_secure(
+    ctx: Context<BumpSeed>,
+    key: u64,
+    new_value: u64,
+    bump: u8,
+) -> Result<()> {
+    let (address, expected_bump) =
+        Pubkey::find_program_address(&[key.to_le_bytes().as_ref()], ctx.program_id);
+
+    if address != ctx.accounts.data.key() {
+        return Err(ProgramError::InvalidArgument.into());
+    }
+    if expected_bump != bump {
+        return Err(ProgramError::InvalidArgument.into());
+    }
+
+    ctx.accounts.data.value = new_value;
+    Ok(())
+}
+```
+
+## Use Anchor’s `seeds` and `bump` constraints
+
+Anchor provides a convenient way to derive PDAs in the account validation struct using the `seeds` and `bump` constraints. These can even be combined with the `init` constraint to initialize the account at the intended address. To protect the program from the vulnerability we’ve been discussing throughout this lesson, Anchor does not even allow you to initialize an account at a PDA using anything but the canonical bump. Instead, it uses `find_program_address` to derive the PDA and subsequently performs the initialization.
+
+```rust
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod bump_seed_canonicalization_recommended {
+    use super::*;
+
+    pub fn set_value(ctx: Context<BumpSeed>, _key: u64, new_value: u64) -> Result<()> {
+        ctx.accounts.data.value = new_value;
+        Ok(())
+    }
+}
+
+// initialize account at PDA
+#[derive(Accounts)]
+#[instruction(key: u64)]
+pub struct BumpSeed<'info> {
+  #[account(mut)]
+  payer: Signer<'info>,
+  #[account(
+    init,
+    seeds = [key.to_le_bytes().as_ref()],
+    // derives the PDA using the canonical bump
+    bump,
+    payer = payer,
+    space = 8 + 8
+  )]
+  data: Account<'info, Data>,
+  system_program: Program<'info, System>
+}
+
+#[account]
+pub struct Data {
+    value: u64,
+}
+```
+
+If you aren't initializing an account, you can still validate PDAs with the `seeds` and `bump` constraints. This simply rederives the PDA and compares the derived address with the address of the account passed in.
+
+In this scenario, Anchor *does* allow you to specify the bump to use to derive the PDA with `bump = <some_bump>`. The intent here is not for you to use arbitrary bumps, but rather to let you optimize your program. The iterative nature of `find_program_address` makes it expensive, so best practice is to store the canonical bump in the PDA account's data upon initializing a PDA, allowing you to reference the bump stored when validating the PDA in subsequent instructions.
+
+When you specify the bump to use, Anchor uses `create_program_address` with the provided bump instead of `find_program_address`. This pattern of storing the bump in the account data ensures that your program always uses the canonical bump without degrading performance.
+
+```rust
+use anchor_lang::prelude::*;
+
+declare_id!("CVwV9RoebTbmzsGg1uqU1s4a3LvTKseewZKmaNLSxTqc");
+
+#[program]
+pub mod bump_seed_canonicalization_recommended {
+    use super::*;
+
+    pub fn set_value(ctx: Context<BumpSeed>, _key: u64, new_value: u64) -> Result<()> {
+        ctx.accounts.data.value = new_value;
+        // store the bump on the account
+        ctx.accounts.data.bump = *ctx.bumps.get("data").unwrap();
+        Ok(())
+    }
+
+    pub fn verify_address(ctx: Context<VerifyAddress>, _key: u64) -> Result<()> {
+        msg!("PDA confirmed to be derived with canonical bump: {}", ctx.accounts.data.key());
+        Ok(())
+    }
+}
+
+// initialize account at PDA
+#[derive(Accounts)]
+#[instruction(key: u64)]
+pub struct BumpSeed<'info> {
+  #[account(mut)]
+  payer: Signer<'info>,
+  #[account(
+    init,
+    seeds = [key.to_le_bytes().as_ref()],
+    // derives the PDA using the canonical bump
+    bump,
+    payer = payer,
+    space = 8 + 8 + 1
+  )]
+  data: Account<'info, Data>,
+  system_program: Program<'info, System>
+}
+
+#[derive(Accounts)]
+#[instruction(key: u64)]
+pub struct VerifyAddress<'info> {
+  #[account(
+    seeds = [key.to_le_bytes().as_ref()],
+    // guranteed to be the canonical bump every time
+    bump = data.bump
+  )]
+  data: Account<'info, Data>,
+}
+
+#[account]
+pub struct Data {
+    value: u64,
+    // bump field
+    bump: u8
+}
+```
+
+If you don't specify the bump on the `bump` constraint, Anchor will still use `find_program_address` to derive the PDA using the canonical bump. As a consequence, your instruction will incur a variable amount of compute budget. Programs that are already at risk of exceeding their compute budget should use this with care since there is a chance that the program’s budget may be occasionally and unpredictably exceeded.
+
+On the other hand, if you only need to verify the address of a PDA passed in without initializing an account, you'll be forced to either let Anchor derive the canonical bump or expose your program to unecessary risks. In that case, please use the canonical bump despite the slight mark against performance.
+
+# Demo
+
+To demonstrate the security exploits possible when you don't check for the canonical bump, let's work with a program that lets each program user "claim" rewards on time.
+
+### 1. Setup
+
+Start by getting the code on the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/starter).
+
+Notice that there are two instructions on the program and a single test in the `tests` directory.
+
+The instructions on the program are:
+
+1. `create_user_insecure`
+2. `claim_insecure`
+
+The `create_user_insecure` instruction simply creates a new account at a PDA derived using the signer's public key and a passed-in bump. 
+
+The `claim_insecure` instruction mints 10 tokens to the user and then marks the account's rewards as claimed so that they can't claim again.
+
+However, the program doesn't explicitly check that the PDAs in question are using the canonical bump.
+
+Have a look at the program to understand what it does before proceeding.
+
+### 2. Test insecure instructions
+
+Since the instructions don't explicitly require the `user` PDA to use the canonical bump, an attacker can create multiple accounts per wallet and claim more rewards than should be allowed.
+
+The test in the `tests` directory creates a new keypair called `attacker` to represent an attacker. It then loops through all possible bumps and calls `create_user_insecure` and `claim_insecure`. By the end, the test expects that the attacker has been able to claim rewards multiple times and has earned more than the 10 tokens allotted per user.
+
+```ts
+it("Attacker can claim more than reward limit with insecure instructions", async () => {
+    const attacker = Keypair.generate()
+    await safeAirdrop(attacker.publicKey, provider.connection)
+    const ataKey = await getAssociatedTokenAddress(mint, attacker.publicKey)
+
+    let numClaims = 0
+
+    for (let i = 0; i < 256; i++) {
+      try {
+        const pda = createProgramAddressSync(
+          [attacker.publicKey.toBuffer(), Buffer.from([i])],
+          program.programId
+        )
+        await program.methods
+          .createUserInsecure(i)
+          .accounts({
+            user: pda,
+            payer: attacker.publicKey,
+          })
+          .signers([attacker])
+          .rpc()
+        await program.methods
+          .claimInsecure(i)
+          .accounts({
+            user: pda,
+            mint,
+            payer: attacker.publicKey,
+            userAta: ataKey,
+          })
+          .signers([attacker])
+          .rpc()
+
+        numClaims += 1
+      } catch (error) {
+        if (
+          error.message !== "Invalid seeds, address must fall off the curve"
+        ) {
+          console.log(error)
+        }
+      }
+    }
+
+    const ata = await getAccount(provider.connection, ataKey)
+
+    console.log(
+      `Attacker claimed ${numClaims} times and got ${Number(ata.amount)} tokens`
+    )
+
+    expect(numClaims).to.be.greaterThan(1)
+    expect(Number(ata.amount)).to.be.greaterThan(10)
+})
+```
+
+Run `anchor test` to see that this test passes, showing that the attacker is successful. Since the test calles the instructions for every valid bump, it takes a bit to run, so be patient.
+
+```bash
+  bump-seed-canonicalization
+Attacker claimed 129 times and got 1290 tokens
+    ✔ Attacker can claim more than reward limit with insecure instructions (133840ms)
+```
+
+### 3. Create secure instructions
+
+Let's demonstrate patching the vulnerability by creating two new instructions:
+
+1. `create_user_secure`
+2. `claim_secure`
+
+Before we write the account validation or instruction logic, let's create a new user type, `UserSecure`. This new type will add the canonical bump as a field on the struct.
+
+```rust
+#[account]
+pub struct UserSecure {
+    auth: Pubkey,
+    bump: u8,
+    rewards_claimed: bool,
+}
+```
+
+Next, let's create account validation structs for each of the new instructions. They'll be very similar to the insecure versions but will let Anchor handle the derivation and deserialization of the PDAs.
+
+```rust
+#[derive(Accounts)]
+pub struct CreateUserSecure<'info> {
+    #[account(mut)]
+    payer: Signer<'info>,
+    #[account(
+        init,
+        seeds = [payer.key().as_ref()],
+        // derives the PDA using the canonical bump
+        bump,
+        payer = payer,
+        space = 8 + 32 + 1 + 1
+    )]
+    user: Account<'info, UserSecure>,
+    system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct SecureClaim<'info> {
+    #[account(
+        seeds = [payer.key().as_ref()],
+        bump = user.bump,
+        constraint = !user.rewards_claimed @ ClaimError::AlreadyClaimed,
+        constraint = user.auth == payer.key()
+    )]
+    user: Account<'info, UserSecure>,
+    #[account(mut)]
+    payer: Signer<'info>,
+    #[account(
+        init_if_needed,
+        payer = payer,
+        associated_token::mint = mint,
+        associated_token::authority = payer
+    )]
+    user_ata: Account<'info, TokenAccount>,
+    #[account(mut)]
+    mint: Account<'info, Mint>,
+    /// CHECK: mint auth PDA
+    #[account(seeds = ["mint".as_bytes().as_ref()], bump)]
+    pub mint_authority: UncheckedAccount<'info>,
+    token_program: Program<'info, Token>,
+    associated_token_program: Program<'info, AssociatedToken>,
+    system_program: Program<'info, System>,
+    rent: Sysvar<'info, Rent>,
+}
+```
+
+Finally, let's implement the instruction logic for the two new instructions. The `create_user_secure` instruction simply needs to set the `auth`, `bump` and `rewards_claimed` fields on the `user` account data.
+
+```rust
+pub fn create_user_secure(ctx: Context<CreateUserSecure>) -> Result<()> {
+    ctx.accounts.user.auth = ctx.accounts.payer.key();
+    ctx.accounts.user.bump = *ctx.bumps.get("user").unwrap();
+    ctx.accounts.user.rewards_claimed = false;
+    Ok(())
+}
+```
+
+The `claim_secure` instruction needs to mint 10 tokens to the user and set the `user` account's `rewards_claimed` field to `true`.
+
+```rust
+pub fn claim_secure(ctx: Context<SecureClaim>) -> Result<()> {
+    token::mint_to(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            MintTo {
+                mint: ctx.accounts.mint.to_account_info(),
+                to: ctx.accounts.user_ata.to_account_info(),
+                authority: ctx.accounts.mint_authority.to_account_info(),
+            },
+            &[&[
+                    b"mint".as_ref(),
+                &[*ctx.bumps.get("mint_authority").unwrap()],
+            ]],
+        ),
+        10,
+    )?;
+
+    ctx.accounts.user.rewards_claimed = true;
+
+    Ok(())
+}
+```
+
+### 4. Test secure instructions
+
+Let's go ahead and write a test to show that the attacker can no longer claim more than once using the new instructions.
+
+Notice that if you start to loop through using multiple PDAs like the old test, you can't even pass the non-canonical bump to the instructions. However, you can still loop through using the various PDAs and at the end check that only 1 claim happened for a total of 10 tokens. Your final test will look something like this:
+
+```ts
+it.only("Attacker can only claim once with secure instructions", async () => {
+    const attacker = Keypair.generate()
+    await safeAirdrop(attacker.publicKey, provider.connection)
+    const ataKey = await getAssociatedTokenAddress(mint, attacker.publicKey)
+    const [userPDA] = findProgramAddressSync(
+      [attacker.publicKey.toBuffer()],
+      program.programId
+    )
+
+    await program.methods
+      .createUserSecure()
+      .accounts({
+        payer: attacker.publicKey,
+      })
+      .signers([attacker])
+      .rpc()
+
+    await program.methods
+      .claimSecure()
+      .accounts({
+        payer: attacker.publicKey,
+        userAta: ataKey,
+        mint,
+        user: userPDA,
+      })
+      .signers([attacker])
+      .rpc()
+
+    let numClaims = 1
+
+    for (let i = 0; i < 256; i++) {
+      try {
+        const pda = createProgramAddressSync(
+          [attacker.publicKey.toBuffer(), Buffer.from([i])],
+          program.programId
+        )
+        await program.methods
+          .createUserSecure()
+          .accounts({
+            user: pda,
+            payer: attacker.publicKey,
+          })
+          .signers([attacker])
+          .rpc()
+
+        await program.methods
+          .claimSecure()
+          .accounts({
+            payer: attacker.publicKey,
+            userAta: ataKey,
+            mint,
+            user: pda,
+          })
+          .signers([attacker])
+          .rpc()
+
+        numClaims += 1
+      } catch {}
+    }
+
+    const ata = await getAccount(provider.connection, ataKey)
+
+    expect(Number(ata.amount)).to.equal(10)
+    expect(numClaims).to.equal(1)
+})
+```
+
+```bash
+  bump-seed-canonicalization
+Attacker claimed 119 times and got 1190 tokens
+    ✔ Attacker can claim more than reward limit with insecure instructions (128493ms)
+    ✔ Attacker can only claim once with secure instructions (1448ms)
+```
+
+If you use Anchor for all of the PDA derivations, this particular exploit is pretty simple to avoid. However, if you end up doing anything "non-standard," be careful to design your program to explicitly use the canonical bump!
+
+If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-bump-seed-canonicalization/tree/solution).
+
+# Challenge
+
+Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+
+Take some time to review at least one program and ensure that all PDA derivations and checks are using the canonical bump.
+
+Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.

--- a/course/content/closing-accounts.md
+++ b/course/content/closing-accounts.md
@@ -1,0 +1,460 @@
+# Closing Accounts and Revival Attacks
+
+# Lesson Objectives
+
+*By the end of this lesson, you will be able to:*
+
+- Explain the various security vulnerabilities associated with closing program accounts incorrectly
+- Close program accounts safely and securely using native Rust
+- Close program accounts safely and securely using the Anchor `close` constraint
+
+# TL;DR
+
+- **Closing an account** improperly creates an opportunity for reinitialization/revival attacks
+- The Solana runtime **garbage collects accounts** when they are no longer rent exempt. Closing accounts involves transferring the lamports stored in the account for rent exemption to another account of your choosing.
+- You can use the Anchor `#[account(close = <address_to_send_lamports>)]` constraint to securely close accounts and set the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`
+    ```rust
+    #[account(mut, close = receiver)]
+    pub data_account: Account<'info, MyData>,
+    #[account(mut)]
+    pub receiver: SystemAccount<'info>
+    ```
+
+# Overview
+
+While it sounds simple, closing accounts properly can be tricky. There are a number of ways an attacker could circumvent having the account closed if you don't follow specific steps.
+
+To get a better understanding of these attack vectors, let’s explore each of these scenarios in depth.
+
+## Insecure account closing
+
+At its core, closing an account involves transferring its lamports to a separate account, thus triggering the Solana runtime to garbage collect the first account. This resets the owner from the owning program to the system program.
+
+Take a look at the example below. The instruction requires two accounts:
+
+1. `account_to_close` - the account to be closed
+2. `destination` - the account that should receive the closed account’s lamports
+
+The program logic is intended to close an account by simply increasing the `destination` account’s lamports by the amount stored in the `account_to_close` and setting the `account_to_close` lamports to 0. With this program, after a full transaction is processed, the `account_to_close` will be garbage collected by the runtime.
+
+```rust
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod closing_accounts_insecure {
+    use super::*;
+
+    pub fn close(ctx: Context<Close>) -> ProgramResult {
+        let dest_starting_lamports = ctx.accounts.destination.lamports();
+
+        **ctx.accounts.destination.lamports.borrow_mut() = dest_starting_lamports
+            .checked_add(ctx.accounts.account_to_close.to_account_info().lamports())
+            .unwrap();
+        **ctx.accounts.account_to_close.to_account_info().lamports.borrow_mut() = 0;
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Close<'info> {
+    account_to_close: Account<'info, Data>,
+    destination: AccountInfo<'info>,
+}
+
+#[account]
+pub struct Data {
+    data: u64,
+}
+```
+
+However, the garbage collection doesn't occur until the transaction completes. And since there can be multiple instructions in a transaction, this creates an opportunity for an attacker to invoke the instruction to close the account but also include in the transaction a transfer to refund the account's rent exemption lamports. The result is that the account *will not* be garbage collected, opening up a path for the attacker to cause unintended behavior in the program and even drain a protocol.
+
+## Secure account closing
+
+The two most important things you can do to close this loophole are to zero out the account data and add an account discriminator that represents the account has been closed. You need *both* of these things to avoid unintended program behavior.
+
+An account with zeroed out data can still be used for some things, especially if it's a PDA whose address derivation is used within the program for verification purposes. However, the damage may be potentially limited if the attacker can't access the previously-stored data.
+
+To further secure the program, however, closed accounts should be given an account discriminator that designates it as "closed," and all instructions should perform checks on all passed-in accounts that return an error if the account is marked closed.
+
+Look at the example below. This program transfers the lamports out of an account, zeroes out the account data, and sets an account discriminator in a single instruction in hopes of preventing a subsequent instruction from utilizing this account again before it has been garbage collected. Failing to do any one of these things would result in a security vulnerability.
+
+```rust
+use anchor_lang::prelude::*;
+use std::io::Write;
+use std::ops::DerefMut;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod closing_accounts_insecure_still_still {
+    use super::*;
+
+    pub fn close(ctx: Context<Close>) -> ProgramResult {
+        let account = ctx.accounts.account.to_account_info();
+
+        let dest_starting_lamports = ctx.accounts.destination.lamports();
+
+        **ctx.accounts.destination.lamports.borrow_mut() = dest_starting_lamports
+            .checked_add(account.lamports())
+            .unwrap();
+        **account.lamports.borrow_mut() = 0;
+
+        let mut data = account.try_borrow_mut_data()?;
+        for byte in data.deref_mut().iter_mut() {
+            *byte = 0;
+        }
+
+        let dst: &mut [u8] = &mut data;
+        let mut cursor = std::io::Cursor::new(dst);
+        cursor
+            .write_all(&anchor_lang::__private::CLOSED_ACCOUNT_DISCRIMINATOR)
+            .unwrap();
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Close<'info> {
+    account: Account<'info, Data>,
+    destination: AccountInfo<'info>,
+}
+
+#[account]
+pub struct Data {
+    data: u64,
+}
+```
+
+Note that the example above is using Anchor's `CLOSED_ACCOUNT_DISCRIMINATOR`. This is simply an account discriminator where each byte is `255`. The discriminator doesn't have any inherent meaning, but if you couple it with account validation checks that return errors any time an account with this discriminator is passed to an instruction, you'll stop your program from unintentionally processing an instruction with a closed account.
+
+### Manual Force Defund
+
+There is still one small issue. While the practice of zeroing out account data and adding a "closed" account discriminator will stop your program from being exploited, a user can still keep an account from being garbage collected by refunding the account's lamports before the end of an instruction. This results in one or potentially many accounts existing in a limbo state where they cannot be used but also cannot be garbage collected.
+
+To handle this edge case, you may consider adding an instruction that will allow *anyone* to defund accounts tagged with the "closed" account discriminator. The only account validation this instruction would perform is to ensure that the account being defunded is marked as closed. It may look something like this:
+
+```rust
+use anchor_lang::__private::CLOSED_ACCOUNT_DISCRIMINATOR;
+use anchor_lang::prelude::*;
+use std::io::{Cursor, Write};
+use std::ops::DerefMut;
+
+...
+
+    pub fn force_defund(ctx: Context<ForceDefund>) -> ProgramResult {
+        let account = &ctx.accounts.account;
+
+        let data = account.try_borrow_data()?;
+        assert!(data.len() > 8);
+
+        let mut discriminator = [0u8; 8];
+        discriminator.copy_from_slice(&data[0..8]);
+        if discriminator != CLOSED_ACCOUNT_DISCRIMINATOR {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let dest_starting_lamports = ctx.accounts.destination.lamports();
+
+        **ctx.accounts.destination.lamports.borrow_mut() = dest_starting_lamports
+            .checked_add(account.lamports())
+            .unwrap();
+        **account.lamports.borrow_mut() = 0;
+
+        Ok(())
+    }
+
+...
+
+#[derive(Accounts)]
+pub struct ForceDefund<'info> {
+    account: AccountInfo<'info>,
+    destination: AccountInfo<'info>,
+}
+```
+
+Since anyone can call this instruction, this can act as a deterrent to attempted revival attacks since the attacker is paying for account rent exemption but anyone else can claim the lamports in a refunded account for themselves.
+
+While not necessary, this can help eliminate the waste of space and lamports associated with these "limbo" accounts.
+
+## Use the Anchor `close` constraint
+
+Fortunately, Anchor makes all of this much simpler with the `#[account(close = <target_account>)]` constraint. This constraint handles everything required to securely close an account:
+
+1. Transfers the account’s lamports to the given `<target_account>`
+2. Zeroes out the account data
+3. Sets the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR` variant
+
+All you have to do is add it in the account validation struct to the account you want closed:
+
+```rust
+#[derive(Accounts)]
+pub struct CloseAccount {
+    #[account(
+        mut, 
+        close = receiver
+    )]
+    pub data_account: Account<'info, MyData>,
+    #[account(mut)]
+    pub receiver: SystemAccount<'info>
+}
+```
+
+The `force_defund` instruction is an optional addition that you’ll have to implement on your own if you’d like to utilize it.
+
+# Demo
+
+To clarify how an attacker might take advantage of a revival attack, let's work with a simple lottery program that uses program account state to manage a user's participation in the lottery.
+
+## 1. Setup
+
+Start by getting the code on the `starter` branch from the [following repo](https://github.com/Unboxed-Software/solana-closing-accounts/tree/starter).
+
+The code has two instructions on the program and two tests in the `tests` directory.
+
+The program instructions are:
+
+1. `enter_lottery`
+2. `redeem_rewards_insecure`
+
+When a user calls `enter_lottery`, the program will initialize an account to store some state about the user's lottery entry.
+
+Since this is a simplified example rather than a fully-fledge lottery program, once a user has entered the lottery they can call the `redeem_rewards_insecure` instruction at any time. This instruction will mint the user an amount of Reward tokens proportional to the amount of times the user has entered the lottery. After minting the rewards, the program closes the user's lottery entry.
+
+Take a minute to familiarize yourself with the program code. The `enter_lottery` instruction simply creates an account at a PDA mapped to the user and initializes some state on it.
+
+The `redeem_rewards_insecure` instruction performs some account and data validation, mints tokens to the given token account, then closes the lottery account by removing its lamports.
+
+However, notice the `redeem_rewards_insecure` instruction *only* transfers out the account's lamports, leaving the account open to revival attacks.
+
+## 2. Test Insecure Program
+
+An attacker that successfully keeps their account from closing can then call `redeem_rewards_insecure` multiple times, claiming more rewards than they are owed.
+
+Some starter tests have already been written that showcase this vulnerability. Take a look at the `closing-accounts.ts` file in the `tests` directory. There is some setup in the `before` function, then a test that simply creates a new lottery entry for `attacker`.
+
+Finally, there's a test that demonstrates how an attacker can keep the account alive even after claiming rewards and then claim rewards again. That test looks like this:
+
+```typescript
+it("attacker  can close + refund lottery acct + claim multiple rewards", async () => {
+    // claim multiple times
+    for (let i = 0; i < 2; i++) {
+      const tx = new Transaction()
+      // instruction claims rewards, program will try to close account
+      tx.add(
+        await program.methods
+          .redeemWinningsInsecure()
+          .accounts({
+            lotteryEntry: attackerLotteryEntry,
+            user: attacker.publicKey,
+            userAta: attackerAta,
+            rewardMint: rewardMint,
+            mintAuth: mintAuth,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .instruction()
+      )
+
+      // user adds instruction to refund dataAccount lamports
+      const rentExemptLamports =
+        await provider.connection.getMinimumBalanceForRentExemption(
+          82,
+          "confirmed"
+        )
+      tx.add(
+        SystemProgram.transfer({
+          fromPubkey: attacker.publicKey,
+          toPubkey: attackerLotteryEntry,
+          lamports: rentExemptLamports,
+        })
+      )
+      // send tx
+      await sendAndConfirmTransaction(provider.connection, tx, [attacker])
+      await new Promise((x) => setTimeout(x, 5000))
+    }
+
+    const ata = await getAccount(provider.connection, attackerAta)
+    const lotteryEntry = await program.account.lotteryAccount.fetch(
+      attackerLotteryEntry
+    )
+
+    expect(Number(ata.amount)).to.equal(
+      lotteryEntry.timestamp.toNumber() * 10 * 2
+    )
+})
+```
+
+This test does the following:
+1. Calls `redeem_rewards_insecure` to redeem the user's rewards
+2. In the same transaction, adds an instruction to refund the user's `lottery_entry` before it can actually be closed
+3. Successfully repeats steps 1 and 2, redeeming rewards for a second time.
+
+You can theoretically repeat steps 1-2 infinitely until either a) the program has no more rewards to give or b) someone notices and patches the exploit. This would obviously be a severe problem in any real program as it allows a malicious attacker to drain an entire rewards pool.
+
+## 3. Create a `redeem_rewards_secure` instruction
+
+To prevent this from happening we're going to create a new instruction that closes the lottery account seucrely using the Anchor `close` constraint. Feel free to try this out on your own if you'd like.
+
+The new account validation struct called `RedeemWinningsSecure` should look like this:
+
+```rust
+#[derive(Accounts)]
+pub struct RedeemWinningsSecure<'info> {
+    // program expects this account to be initialized
+    #[account(
+        mut,
+        seeds = [user.key().as_ref()],
+        bump = lottery_entry.bump,
+        has_one = user,
+        close = user
+    )]
+    pub lottery_entry: Account<'info, LotteryAccount>,
+    #[account(mut)]
+    pub user: Signer<'info>,
+    #[account(
+        mut,
+        constraint = user_ata.key() == lottery_entry.user_ata
+    )]
+    pub user_ata: Account<'info, TokenAccount>,
+    #[account(
+        mut,
+        constraint = reward_mint.key() == user_ata.mint
+    )]
+    pub reward_mint: Account<'info, Mint>,
+    ///CHECK: mint authority
+    #[account(
+        seeds = [MINT_SEED.as_bytes()],
+        bump
+    )]
+    pub mint_auth: AccountInfo<'info>,
+    pub token_program: Program<'info, Token>
+}
+```
+
+It should be the exact same as the original `RedeemWinnings` account validation struct, except there is an additional `close = user` constraint on the `lottery_entry` account. This will tell Anchor to close the account by zeroing out the data, transferring its lamports to the `user` account, and setting the account discriminator to the `CLOSED_ACCOUNT_DISCRIMINATOR`. This last step is what will prevent the account from being used again if the program has attempted to close it already.
+
+Then, we can create a `mint_ctx` method on the new `RedeemWinningsSecure` struct to help with the minting CPI to the token program.
+
+```Rust
+impl<'info> RedeemWinningsSecure <'info> {
+    pub fn mint_ctx(&self) -> CpiContext<'_, '_, '_, 'info, MintTo<'info>> {
+        let cpi_program = self.token_program.to_account_info();
+        let cpi_accounts = MintTo {
+            mint: self.reward_mint.to_account_info(),
+            to: self.user_ata.to_account_info(),
+            authority: self.mint_auth.to_account_info()
+        };
+
+        CpiContext::new(cpi_program, cpi_accounts)
+    }
+}
+```
+
+Finally, the logic for the new secure instruction should look like this:
+
+```rust
+pub fn redeem_winnings_secure(ctx: Context<RedeemWinningsSecure>) -> Result<()> {
+
+    msg!("Calculating winnings");
+    let amount = ctx.accounts.lottery_entry.timestamp as u64 * 10;
+
+    msg!("Minting {} tokens in rewards", amount);
+    // program signer seeds
+    let auth_bump = *ctx.bumps.get("mint_auth").unwrap();
+    let auth_seeds = &[MINT_SEED.as_bytes(), &[auth_bump]];
+    let signer = &[&auth_seeds[..]];
+
+    // redeem rewards by minting to user
+    mint_to(ctx.accounts.mint_ctx().with_signer(signer), amount)?;
+
+    Ok(())
+}
+```
+
+This logic simply calculates the rewards for the claiming user and transfers the rewards. However, because of the `close` constraint in the account validation struct, the attacker shouldn't be able to call this instruction multiple times.
+
+## 4. Test the Program
+
+To test our new secure instruction, let's create a new test that trys to call `redeemingWinningsSecure` twice. We expect the second call to throw an error.
+
+```typescript
+it("attacker cannot claim multiple rewards with secure claim", async () => {
+    const tx = new Transaction()
+    // instruction claims rewards, program will try to close account
+    tx.add(
+      await program.methods
+        .redeemWinningsSecure()
+        .accounts({
+          lotteryEntry: attackerLotteryEntry,
+          user: attacker.publicKey,
+          userAta: attackerAta,
+          rewardMint: rewardMint,
+          mintAuth: mintAuth,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .instruction()
+    )
+
+    // user adds instruction to refund dataAccount lamports
+    const rentExemptLamports =
+      await provider.connection.getMinimumBalanceForRentExemption(
+        82,
+        "confirmed"
+      )
+    tx.add(
+      SystemProgram.transfer({
+        fromPubkey: attacker.publicKey,
+        toPubkey: attackerLotteryEntry,
+        lamports: rentExemptLamports,
+      })
+    )
+    // send tx
+    await sendAndConfirmTransaction(provider.connection, tx, [attacker])
+
+    try {
+      await program.methods
+        .redeemWinningsSecure()
+        .accounts({
+          lotteryEntry: attackerLotteryEntry,
+          user: attacker.publicKey,
+          userAta: attackerAta,
+          rewardMint: rewardMint,
+          mintAuth: mintAuth,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .signers([attacker])
+        .rpc()
+    } catch (error) {
+      console.log(error.message)
+      expect(error)
+    }
+})
+```
+
+Run `anchor test` to see that the test passes. The output will look something like this:
+
+```bash
+  closing-accounts
+    ✔ Enter lottery (451ms)
+    ✔ attacker can close + refund lottery acct + claim multiple rewards (18760ms)
+AnchorError caused by account: lottery_entry. Error Code: AccountDiscriminatorMismatch. Error Number: 3002. Error Message: 8 byte discriminator did not match what was expected.
+    ✔ attacker cannot claim multiple rewards with secure claim (414ms)
+```
+
+Note, this does not prevent the malicious user from refunding their account altogether - it just protects our program from accidentally re-using the account when it should be closed. We haven't implemented a `force_defund` instruction so far, but we could. If you're feeling up for it, give it a try yourself!
+
+The simplest and most secure way to close accounts is using Anchor's `close` constraint. If you ever need more custom behavior and can't use this constraint, make sure to replicate its functionality to ensure your program is secure.
+
+If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-closing-accounts/tree/solution).
+
+# Challenge
+
+Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+
+Take some time to review at least one program and ensure that when accounts are closed they're not susceptible to revival attacks.
+
+Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.

--- a/course/content/pda-sharing.md
+++ b/course/content/pda-sharing.md
@@ -1,0 +1,484 @@
+# PDA Sharing
+
+# Lesson Objectives
+
+*By the end of this lesson, you will be able to:*
+
+- Explain the security risks associated with PDA sharing
+- Derive PDAs that have discrete authority domains
+- Use Anchor’s `seeds` and `bump` constraints to validate PDA accounts
+
+# TL;DR
+
+- Using the same PDA for multiple authority domains opens your program up to the possibility of users accessing data and funds that don't belong to them
+- Prevent the same PDA from being used for multiple accounts by using seeds that are user and/or domain-specific
+- Use Anchor’s `seeds` and `bump` constraints to validate that a PDA is derived using the expected seeds and bump
+
+# Overview
+
+PDA sharing refers to using the same PDA as a signer across multiple users or domains. Especially when using PDAs for signing, it may seem appropriate to use a global PDA to represent the program. However, this opens up the possibility of account validation passing but a user being able to access funds, transfers, or data not belonging to them.
+
+## Insecure global PDA
+
+In the example below, the `authority` of the `vault` account is a PDA derived using the `mint` address stored on the `pool` account. This PDA is passed into the instruction as the `authority` account to sign for the transfer tokens from the `vault` to the `withdraw_destination`.
+
+Using the `mint` address as a seed to derive the PDA to sign for the `vault` is insecure because multiple `pool` accounts could be created for the same `vault` token account, but a different `withdraw_destination`. By using the `mint` as a seed derive the PDA to sign for token transfers, any `pool` account could sign for the transfer of tokens from a `vault` token account to an arbitrary `withdraw_destination`.
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod pda_sharing_insecure {
+    use super::*;
+
+    pub fn withdraw_tokens(ctx: Context<WithdrawTokens>) -> Result<()> {
+        let amount = ctx.accounts.vault.amount;
+        let seeds = &[ctx.accounts.pool.mint.as_ref(), &[ctx.accounts.pool.bump]];
+        token::transfer(ctx.accounts.transfer_ctx().with_signer(&[seeds]), amount)
+    }
+}
+
+#[derive(Accounts)]
+pub struct WithdrawTokens<'info> {
+    #[account(has_one = vault, has_one = withdraw_destination)]
+    pool: Account<'info, TokenPool>,
+    vault: Account<'info, TokenAccount>,
+    withdraw_destination: Account<'info, TokenAccount>,
+    authority: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+}
+
+impl<'info> WithdrawTokens<'info> {
+    pub fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, token::Transfer<'info>> {
+        let program = self.token_program.to_account_info();
+        let accounts = token::Transfer {
+            from: self.vault.to_account_info(),
+            to: self.withdraw_destination.to_account_info(),
+            authority: self.authority.to_account_info(),
+        };
+        CpiContext::new(program, accounts)
+    }
+}
+
+#[account]
+pub struct TokenPool {
+    vault: Pubkey,
+    mint: Pubkey,
+    withdraw_destination: Pubkey,
+    bump: u8,
+}
+```
+
+## Secure account specific PDA
+
+One approach to create an account specific PDA is to use the `withdraw_destination` as a seed to derive the PDA used as the authority of the `vault` token account. This ensures the PDA signing for the CPI in the `withdraw_tokens` instruction is derived using the intended `withdraw_destination` token account. In other words, tokens from a `vault` token account can only be withdrawn to the `withdraw_destination` that was originally initialized with the `pool` account.
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod pda_sharing_secure {
+    use super::*;
+
+    pub fn withdraw_tokens(ctx: Context<WithdrawTokens>) -> Result<()> {
+        let amount = ctx.accounts.vault.amount;
+        let seeds = &[
+            ctx.accounts.pool.withdraw_destination.as_ref(),
+            &[ctx.accounts.pool.bump],
+        ];
+        token::transfer(ctx.accounts.transfer_ctx().with_signer(&[seeds]), amount)
+    }
+}
+
+#[derive(Accounts)]
+pub struct WithdrawTokens<'info> {
+    #[account(has_one = vault, has_one = withdraw_destination)]
+    pool: Account<'info, TokenPool>,
+    vault: Account<'info, TokenAccount>,
+    withdraw_destination: Account<'info, TokenAccount>,
+    authority: AccountInfo<'info>,
+    token_program: Program<'info, Token>,
+}
+
+impl<'info> WithdrawTokens<'info> {
+    pub fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, token::Transfer<'info>> {
+        let program = self.token_program.to_account_info();
+        let accounts = token::Transfer {
+            from: self.vault.to_account_info(),
+            to: self.withdraw_destination.to_account_info(),
+            authority: self.authority.to_account_info(),
+        };
+        CpiContext::new(program, accounts)
+    }
+}
+
+#[account]
+pub struct TokenPool {
+    vault: Pubkey,
+    mint: Pubkey,
+    withdraw_destination: Pubkey,
+    bump: u8,
+}
+```
+
+## Anchor’s `seeds` and `bump` constraints
+
+PDAs can be used as both the address of an account and allow programs to sign for the PDAs they own.
+
+The example below uses a PDA derived using the `withdraw_destination` as both the address of the `pool` account and owner of the `vault` token account. This means that only the `pool` account associated with correct `vault` and `withdraw_destination` can be used in the `withdraw_tokens` instruction.
+
+You can use Anchor’s `seeds` and `bump` constraints with the `#[account(...)]` attribute to validate the `pool` account PDA. Anchor derives a PDA using the `seeds` and `bump` specified and compare against the account passed into the instruction as the `pool` account. The `has_one` constraint is used to further ensure that only the correct accounts stored on the `pool` account are passed into the instruction. 
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod pda_sharing_recommended {
+    use super::*;
+
+    pub fn withdraw_tokens(ctx: Context<WithdrawTokens>) -> Result<()> {
+        let amount = ctx.accounts.vault.amount;
+        let seeds = &[
+            ctx.accounts.pool.withdraw_destination.as_ref(),
+            &[ctx.accounts.pool.bump],
+        ];
+        token::transfer(ctx.accounts.transfer_ctx().with_signer(&[seeds]), amount)
+    }
+}
+
+#[derive(Accounts)]
+pub struct WithdrawTokens<'info> {
+    #[account(
+				has_one = vault,
+				has_one = withdraw_destination,
+				seeds = [withdraw_destination.key().as_ref()],
+				bump = pool.bump,
+		)]
+    pool: Account<'info, TokenPool>,
+    vault: Account<'info, TokenAccount>,
+    withdraw_destination: Account<'info, TokenAccount>,
+    token_program: Program<'info, Token>,
+}
+
+impl<'info> WithdrawTokens<'info> {
+    pub fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, token::Transfer<'info>> {
+        let program = self.token_program.to_account_info();
+        let accounts = token::Transfer {
+            from: self.vault.to_account_info(),
+            to: self.withdraw_destination.to_account_info(),
+            authority: self.pool.to_account_info(),
+        };
+        CpiContext::new(program, accounts)
+    }
+}
+
+#[account]
+pub struct TokenPool {
+    vault: Pubkey,
+    mint: Pubkey,
+    withdraw_destination: Pubkey,
+    bump: u8,
+}
+```
+
+# Demo
+
+Let’s practice by creating a simple program to demonstrate how a PDA sharing can allow an attacker to withdraw tokens that don’t belong to them. This demo expands on the examples above by including the instructions to initialize the required program accounts.
+
+### 1. Starter
+
+To get started, download the starter code on the `starter` branch of [this repository](https://github.com/Unboxed-Software/solana-pda-sharing/tree/starter). The starter code includes a program with two instructions and the boilerplate setup for the test file.
+
+The `initialize_pool` instruction initializes a new `TokenPool` that stores a `vault`, `mint`, `withdraw_destination`, and `bump`. The `vault` is a token account where the authority is set as a PDA derived using the `mint` address.
+
+The `withdraw_insecure` instruction will transfer tokens in the `vault` token account to a `withdraw_destination` token account. 
+
+However, as written the seeds used for signing are not specific to the vault's withdraw destination, thus opening up the program to security exploits. Take a minute to familiarize yourself with the code before continuing on.
+
+### 2. Test `withdraw_insecure` instruction
+
+The test file includes the code to invoke the `initialize_pool` instruction and then mint 100 tokens to the `vault` token account. It also includes a test to invoke the `withdraw_insecure` using the intended `withdraw_destination`. This shows that the instructions can be used as intended.
+
+After that, there are two more tests to show how the instructions are vulnerable to exploit.
+
+The first test invokes the `initialize_pool` instruction to create a "fake" `pool` account using the same `vault` token account, but a different `withdraw_destination`.
+
+The second test withdraws from this pool, effectively stealing funds from the vault.
+
+```tsx
+it("Insecure initialize allows pool to be initialized with wrong vault", async () => {
+    await program.methods
+      .initializePool(authInsecureBump)
+      .accounts({
+        pool: poolInsecureFake.publicKey,
+        mint: mint,
+        vault: vaultInsecure.address,
+        withdrawDestination: withdrawDestinationFake,
+        payer: walletFake.publicKey,
+      })
+      .signers([walletFake, poolInsecureFake])
+      .rpc()
+
+    await new Promise((x) => setTimeout(x, 1000))
+
+    await spl.mintTo(
+      connection,
+      wallet.payer,
+      mint,
+      vaultInsecure.address,
+      wallet.payer,
+      100
+    )
+
+    const account = await spl.getAccount(connection, vaultInsecure.address)
+    expect(Number(account.amount)).to.equal(100)
+})
+
+it("Insecure withdraw allows stealing from vault", async () => {
+    await program.methods
+      .withdrawInsecure()
+      .accounts({
+        pool: poolInsecureFake.publicKey,
+        vault: vaultInsecure.address,
+        withdrawDestination: withdrawDestinationFake,
+        authority: authInsecure,
+        signer: walletFake.publicKey,
+      })
+      .signers([walletFake])
+      .rpc()
+
+    const account = await spl.getAccount(connection, vaultInsecure.address)
+    expect(Number(account.amount)).to.equal(0)
+})
+```
+
+Run `anchor test` to see that the transactions complete successfully and the `withdraw_instrucure` instruction allows the `vault` token account to be drained to a fake withdraw destination stored on the fake `pool` account.
+
+### 3. Add `initialize_pool_secure` instruction
+
+Now let's add a new instruction to the program for securely initializing a pool. 
+
+This new `initialize_pool_secure` instruction will initialize a `pool` account as a PDA derived using the `withdraw_destination`. It will also initialize a `vault` token account with the authority set as the `pool` PDA.
+
+```rust
+pub fn initialize_pool_secure(ctx: Context<InitializePoolSecure>) -> Result<()> {
+    ctx.accounts.pool.vault = ctx.accounts.vault.key();
+    ctx.accounts.pool.mint = ctx.accounts.mint.key();
+    ctx.accounts.pool.withdraw_destination = ctx.accounts.withdraw_destination.key();
+    ctx.accounts.pool.bump = *ctx.bumps.get("pool").unwrap();
+    Ok(())
+}
+
+...
+
+#[derive(Accounts)]
+pub struct InitializePoolSecure<'info> {
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + 32 + 32 + 32 + 1,
+        seeds = [withdraw_destination.key().as_ref()],
+        bump
+    )]
+    pub pool: Account<'info, TokenPool>,
+    pub mint: Account<'info, Mint>,
+    #[account(
+        init,
+        payer = payer,
+        token::mint = mint,
+        token::authority = pool,
+    )]
+    pub vault: Account<'info, TokenAccount>,
+    pub withdraw_destination: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+    pub rent: Sysvar<'info, Rent>,
+}
+```
+
+### 4. Add `withdraw_secure` instruction
+
+Next, add a `withdraw_secure` instruction. This instruction will withdraw tokens from the `vault` token account to the `withdraw_destination`. The `pool` account is validated using the `seeds` and `bump` constraints to ensure the correct PDA account is provided. The `has_one` constraints check that the correct `vault` and `withdraw_destination` token accounts are provided. 
+
+```rust
+pub fn withdraw_secure(ctx: Context<WithdrawTokensSecure>) -> Result<()> {
+    let amount = ctx.accounts.vault.amount;
+    let seeds = &[
+    ctx.accounts.pool.withdraw_destination.as_ref(),
+      &[ctx.accounts.pool.bump],
+    ];
+    token::transfer(ctx.accounts.transfer_ctx().with_signer(&[seeds]), amount)
+}
+
+...
+
+#[derive(Accounts)]
+pub struct WithdrawTokensSecure<'info> {
+    #[account(
+        has_one = vault,
+        has_one = withdraw_destination,
+        seeds = [withdraw_destination.key().as_ref()],
+        bump = pool.bump,
+    )]
+    pool: Account<'info, TokenPool>,
+    #[account(mut)]
+    vault: Account<'info, TokenAccount>,
+    #[account(mut)]
+    withdraw_destination: Account<'info, TokenAccount>,
+    token_program: Program<'info, Token>,
+}
+
+impl<'info> WithdrawTokensSecure<'info> {
+    pub fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, token::Transfer<'info>> {
+        let program = self.token_program.to_account_info();
+        let accounts = token::Transfer {
+            from: self.vault.to_account_info(),
+            to: self.withdraw_destination.to_account_info(),
+            authority: self.pool.to_account_info(),
+        };
+        CpiContext::new(program, accounts)
+    }
+}
+```
+
+### 5. Test `withdraw_secure` instruction
+
+Finally, return to the test file to test the `withdraw_secure` instruction and show that by narrowing the scope of our PDA signing authority, we've removed the vulnerability.
+
+Before we write a test showing the vulnerability has been patched let's write a test that simply shows that the initialization and withdraw instructions work as expected:
+
+```typescript
+it("Secure pool initialization and withdraw works", async () => {
+    const withdrawDestinationAccount = await getAccount(
+      provider.connection,
+      withdrawDestination
+    )
+
+    await program.methods
+      .initializePoolSecure()
+      .accounts({
+        pool: authSecure,
+        mint: mint,
+        vault: vaultRecommended.publicKey,
+        withdrawDestination: withdrawDestination,
+      })
+      .signers([vaultRecommended])
+      .rpc()
+
+    await new Promise((x) => setTimeout(x, 1000))
+
+    await spl.mintTo(
+      connection,
+      wallet.payer,
+      mint,
+      vaultRecommended.publicKey,
+      wallet.payer,
+      100
+    )
+
+    await program.methods
+      .withdrawSecure()
+      .accounts({
+        pool: authSecure,
+        vault: vaultRecommended.publicKey,
+        withdrawDestination: withdrawDestination,
+      })
+      .rpc()
+
+    const afterAccount = await getAccount(
+      provider.connection,
+      withdrawDestination
+    )
+
+    expect(
+      Number(afterAccount.amount) - Number(withdrawDestinationAccount.amount)
+    ).to.equal(100)
+})
+```
+
+Now, we'll test that the exploit no longer works. Since the `vault` authority is the `pool` PDA derived using the intended `withdraw_destination` token account, there should no longer be a way to withdraw to an account other than the intended `withdraw_destination`.
+
+Add a test that shows you can't call `withdraw_secure` with the wrong withdrawal destination. It can use the pool and vault created in the previous test.
+
+```typescript
+  it("Secure withdraw doesn't allow withdraw to wrong destination", async () => {
+    try {
+      await program.methods
+        .withdrawSecure()
+        .accounts({
+          pool: authSecure,
+          vault: vaultRecommended.publicKey,
+          withdrawDestination: withdrawDestinationFake,
+        })
+        .signers([walletFake])
+        .rpc()
+
+      assert.fail("expected error")
+    } catch (error) {
+      console.log(error.message)
+      expect(error)
+    }
+  })
+```
+
+Lastly, since the `pool` account is a PDA derived using the `withdraw_destination` token account, we can’t create a fake `pool` account using the same PDA. Add one more test showing that the new `initialize_pool_secure` instruction won't let an attacker put in the wrong vault.
+
+```typescript
+it("Secure pool initialization doesn't allow wrong vault", async () => {
+    try {
+      await program.methods
+        .initializePoolSecure()
+        .accounts({
+          pool: authSecure,
+          mint: mint,
+          vault: vaultInsecure.address,
+          withdrawDestination: withdrawDestination,
+        })
+        .signers([vaultRecommended])
+        .rpc()
+
+      assert.fail("expected error")
+    } catch (error) {
+      console.log(error.message)
+      expect(error)
+    }
+})
+```
+
+Run `anchor test` and to see that the new instructions don't allow an attacker to withdraw from a vault that isn't theirs.
+
+```
+  pda-sharing
+    ✔ Initialize Pool Insecure (981ms)
+    ✔ Withdraw (470ms)
+    ✔ Insecure initialize allows pool to be initialized with wrong vault (10983ms)
+    ✔ Insecure withdraw allows stealing from vault (492ms)
+    ✔ Secure pool initialization and withdraw works (2502ms)
+unknown signer: ARjxAsEPj6YsAPKaBfd1AzUHbNPtAeUsqusAmBchQTfV
+    ✔ Secure withdraw doesn't allow withdraw to wrong destination
+unknown signer: GJcHJLot3whbY1aC9PtCsBYk5jWoZnZRJPy5uUwzktAY
+    ✔ Secure pool initialization doesn't allow wrong vault
+```
+
+And that's it! Unlike some of the other security vulnerabilities we've discussed, this one is more conceptual and can't be fixed by simply using a particular Anchor type. You'll need to think through the architecture of your program and ensure that you aren't sharing PDAs across different domains.
+
+If you want to take a look at the final solution code you can find it on the `solution` branch of [the same repository](https://github.com/Unboxed-Software/solana-pda-sharing/tree/solution).
+
+# Challenge
+
+Just as with other lessons in this module, your opportunity to practice avoiding this security exploit lies in auditing your own or other programs.
+
+Take some time to review at least one program and look for potential vulnerabilities in its PDA structure. PDAs used for signing should be narrow and focused on a single domain as much as possible.
+
+Remember, if you find a bug or exploit in somebody else's program, please alert them! If you find one in your own program, be sure to patch it right away.

--- a/course/content/security-intro.md
+++ b/course/content/security-intro.md
@@ -11,8 +11,8 @@ This module is meant to build on top of that lesson with two goals in mind:
 
 If you went through the Basic Security lesson, the first few lessons should seem familiar. They largely cover topics we discussed in that lesson. After that, some of the attacks may seem new. We encourage you to go through all of them.
 
-The last thing to call out is that the structure of this module is slightly different. Every lesson in this course allows you to choose whether to quickly go through the TL;DR or go through the entire lesson in-depth. As such, the lessons tend to be decently long so that readers can go deep on the material if they so choose. 
+The last thing to call out is that there are a lot more lessons in this module than in prior modules. And the lessons aren't dependent on each other in the same ways, so you can bounce around a bit more if you'd like.
 
-In this module, lessons are much shorter but there are more of them. And within each lesson, there is less prose and more code snippets. We’re hoping this makes it easy for you to skim all of them and really dive into the code on the ones that you don’t fully understand afterward.
+Originally, we were going to have more, shorter lessons in this module. And while they might be shorter than average, they aren't much shorter. It turns out that even though each of the security vulnerabilities is "simple," there's a lot to discuss. So each lesson may have a little bit less prose and more code snippets, making it easy for readers to choose how in depth to go. But, ultimately, each lesson is still as fully-fledged as they have been before so that you can really get a solid grasp on each of the discussed security risks.
 
 As always, we appreciate feedback. Good luck digging in!

--- a/utils/course-map.js
+++ b/utils/course-map.js
@@ -155,7 +155,7 @@ export const modules = [
     },
     {
       title: 'PDA sharing',
-      link: '/content/pda-sharing'
+      link: '/course/pda-sharing'
     }
   ]
 ];

--- a/utils/course-map.js
+++ b/utils/course-map.js
@@ -146,19 +146,16 @@ export const modules = [
       link: '/course/arbitrary-cpi'
     },
     {
-      title: 'PDA sharing - COMING SOON',
-      link: '',
-      ready: false
+      title: 'Bump seed canonicalization',
+      link: '/course/bump-seed-canonicalization'
     },
     {
-      title: 'Bump seed canonicalization - COMING SOON',
-      link: '',
-      ready: false
+      title: 'Closing accounts and revival attacks',
+      link: '/course/closing-accounts'
     },
     {
-      title: 'Closing accounts - COMING SOON',
-      link: '',
-      ready: false
+      title: 'PDA sharing',
+      link: '/content/pda-sharing'
     }
   ]
 ];


### PR DESCRIPTION
# Description

Adds the final three security lessons of the Solana Development Course. Also fixes some minor bugs in the course content. No changes to site functionality.

# Summary of changes:
- Minor fixes to arbitrary CPI lesson
- Minor fixes to security intro
- Adds bump seed canonicalization lesson
- Adds closing accounts lesson
- Adds pda sharing lesson
