### PR TITLE
chore: Bump heroicons from 1.0.6 to 2.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@algolia/autocomplete-core": "^1.7.4",
     "@algolia/autocomplete-preset-algolia": "^1.7.4",
     "@headlessui/react": "^1.7.7",
-    "@heroicons/react": "1.0.6",
+    "@heroicons/react": "2.0.13",
     "@solana/wallet-adapter-base": "^0.9.20",
     "@solana/wallet-adapter-react": "^0.15.27",
     "@solana/wallet-adapter-react-ui": "^0.9.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,10 +241,10 @@
   dependencies:
     client-only "^0.0.1"
 
-"@heroicons/react@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"
-  integrity sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==
+"@heroicons/react@2.0.13":
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.0.13.tgz#9b1cc54ff77d6625c9565efdce0054a4bcd9074c"
+  integrity sha512-iSN5XwmagrnirWlYEWNPdCDj9aRYVD/lnK3JlsC9/+fqGF80k8C7rl+1HCvBX0dBoagKqOFBs6fMhJJ1hOg1EQ==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Upgrading `@heroicons/react` version from `1.0.6` to `2.0.13`
