### PR TITLE
fix: responsive heading in specs and course

### DIFF
--- a/components/course/banner.js
+++ b/components/course/banner.js
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 function CourseBanner() {
   return (
-    <p className="prose flex justify-center pt-1 pb-2 text-gray-700 dark:text-gray-300">
+    <p className="prose flex mx-auto pt-1 pb-2 text-gray-700 dark:text-gray-300">
       <span className="">
         created by{' '}
         <Link

--- a/pages/course/index.js
+++ b/pages/course/index.js
@@ -14,7 +14,7 @@ export default function Course() {
   return (
     <Container metaTags={metaTags}>
       <div className="mx-2">
-        <div className="flex flex-col items-center">
+        <div className="flex flex-col text-center">
           <h1 className="text-2xl font-bold capitalize text-gray-900 dark:text-gray-200 md:text-3xl 2xl:text-4xl">
             Solana Development Course
           </h1>

--- a/pages/specs/index.js
+++ b/pages/specs/index.js
@@ -25,8 +25,8 @@ export default function Specs({content}) {
   return (
     <Container metaTags={metaTags}>
       <div className="mx-2">
-        <div className="flex flex-col items-center">
-          <h1 className="text-xl font-bold capitalize text-gray-900 dark:text-gray-200 md:text-2xl 2xl:text-3xl">
+        <div className="flex flex-col text-center">
+          <h1 className="text-2xl font-bold capitalize text-gray-900 dark:text-gray-200 md:text-3xl 2xl:text-4xl">
             Solana Protocol Specifications
           </h1>
         </div>


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes page headings in specs and course.

Before - specs | After - specs
------- | --------- |
![image](https://user-images.githubusercontent.com/75211982/215781989-2d703abb-0e50-4afe-8b40-628cc9f484d4.png) | ![image](https://user-images.githubusercontent.com/75211982/215782038-136e8048-476b-4cbc-802a-08c95e186c9f.png)

Before - course | After - course
------- | --------- |
![image](https://user-images.githubusercontent.com/75211982/215781530-9a7fcc77-7c29-48d3-8a76-ba71c54224b3.png)| ![image](https://user-images.githubusercontent.com/75211982/215781599-5aa08a89-7cd6-4c8d-bcde-5aec7e527b1e.png)

# Summary
- I had decreased the font size of the specs page heading due to long text and unresponsiveness. This solves this with the correct font size.


# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
