### PR TITLE
fix: margin and filter button position

### DIFF
--- a/src/pages/library/index.tsx
+++ b/src/pages/library/index.tsx
@@ -9,12 +9,12 @@ import { getContentTypes, getRecordsFromSlug } from '@/lib/queries';
 import styles from '@/styles/core/sidebar.module.css';
 import ContentCard from '@/components/core/ContentCard';
 import LibraryFilters from '@/components/library/LibraryFilters';
-import { FunnelIcon } from '@heroicons/react/24/outline';
 import { computeImage } from '@/utils/content';
 import { computeFilterFromUrlParam } from '@/utils/helpers';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { CONTENT_TAGS } from '@/lib/constants/content';
 import Link from 'next/link';
+import { FunnelIcon } from '@heroicons/react/24/outline';
 
 // define the on-page seo metadata
 const seo: NextSeoProps = {
@@ -139,6 +139,13 @@ export default function Page({ records }: PageProps) {
         </p>
       </PageHero>
 
+      <section className="col-span-full mt-6 flex justify-end px-6 lg:hidden">
+        <button className="btn-dark space-x-2" onClick={() => setShowFilters(!showFilters)}>
+          <FunnelIcon className={clsx('icon', showFilters && 'rotate-180')} />
+          <span>Filters</span>
+        </button>
+      </section>
+
       <section className={styles.wrapper + ' container-inner'}>
         <aside
           className={clsx(
@@ -146,13 +153,6 @@ export default function Page({ records }: PageProps) {
             // !showFilters && styles.stickySidebar,
           )}
         >
-          <section className="col-span-full mt-6 flex justify-end px-6 lg:hidden">
-            <button className="btn-dark space-x-2" onClick={() => setShowFilters(!showFilters)}>
-              <FunnelIcon className={clsx('icon', showFilters && 'rotate-180')} />
-              <span>Filters</span>
-            </button>
-          </section>
-
           <div className={showFilters ? styles.floatingMenu : 'hidden lg:block'}>
             <LibraryFilters className={showFilters ? styles.floatingMenuInner : 'divide-y'} />
           </div>

--- a/src/styles/core/sidebar.module.css
+++ b/src/styles/core/sidebar.module.css
@@ -17,6 +17,7 @@
   @apply col-span-full md:col-span-1;
   @apply divide-gray-300 lg:divide-y;
   @apply w-full;
+  @apply lg:ml-4;
 }
 .gridContainer {
   @apply grid gap-6 sm:grid-cols-2 lg:grid-cols-3;
@@ -63,7 +64,7 @@
   @apply pl-8;
 }
 .leftSideSmall .section {
-  @apply pr-8;
+  @apply pr-6;
 }
 
 .section h3 {

--- a/src/styles/core/sidebar.module.css
+++ b/src/styles/core/sidebar.module.css
@@ -64,7 +64,7 @@
   @apply pl-8;
 }
 .leftSideSmall .section {
-  @apply pr-6;
+  @apply pr-8;
 }
 
 .section h3 {


### PR DESCRIPTION
# Description

This PR fixes an issue on the library page where the content tags were sticking to the left side of the window on a small screen, making it difficult to read and interact. It also improves the position of the filter button on the same page.  

- Fixes #5 

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.