### PR TITLE
Add missing style for inline code

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -152,6 +152,10 @@ h6,
   /* @apply tracking-wide; */
 }
 
+.inline-code {
+  @apply rounded-md p-1 font-mono bg-gray-300;
+}
+
 .icon-sm {
   @apply h-3 w-3;
 }


### PR DESCRIPTION
# Description

There's a CSS style for `.inline-code` missing throughout the SolDev UI. 

This PR should hopefully fix it - I couldn't find any info about how this repo interacts with the SolDev repo in the README so it was hard to test. I'm sure you'll know at a glance if I've done it correctly.

# Summary of changes:

Add the necessary style with the required tailwind mixins.

# Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.