### PR TITLE
Only pre-render en pages for simd

### DIFF
--- a/src/pages/simd/[slug].tsx
+++ b/src/pages/simd/[slug].tsx
@@ -44,9 +44,16 @@ export async function getStaticPaths() {
 
 type StaticProps = {
   params: { slug: string };
+  locale: string;
 };
 
-export async function getStaticProps({ params: { slug } }: StaticProps) {
+export async function getStaticProps({ params: { slug }, locale }: StaticProps) {
+  if (locale != 'en') {
+    return {
+      notFound: true
+    };
+  }
+
   // fetch all the SIMD records from GitHub
   const records = await fetchAllSIMD();
 

--- a/src/pages/simd/index.tsx
+++ b/src/pages/simd/index.tsx
@@ -13,7 +13,17 @@ const seo: NextSeoProps = {
     'The Solana Improvement Documents (SIMD) describe proposed and accepted changes to the Solana protocol.'
 };
 
-export async function getStaticProps() {
+type StaticProps = {
+  locale?: string;
+};
+
+export async function getStaticProps({ locale }: StaticProps) {
+  if (locale != 'en') {
+    return {
+      notFound: true
+    };
+  }
+
   const records = await fetchAllSIMD();
 
   return {

--- a/src/utils/fetch-simd.ts
+++ b/src/utils/fetch-simd.ts
@@ -22,7 +22,9 @@ type GitHubProposal = {
 export const fetchSIMDs = async (): Promise<Array<ParsedGitHubPullContent>> => {
   const url =
     'https://api.github.com/repos/solana-foundation/solana-improvement-documents/contents/proposals';
-  const response = await get(url);
+  const response = await get(url, {
+    Authorization: 'Bearer ' + process.env.NEXT_PUBLIC_GITHUB_TOKEN
+  });
 
   if (response.status !== 'OK') {
     throw new Error(`Error ${response.status} from ${url}`);


### PR DESCRIPTION
# Description

Due to issues on deployment, we're restricting SIMD pages to only "en" content.

# Summary of changes:

- Restrict SIMD page generation for "en" content
- Added bearer token to github call to increase rate limits

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.