### PR TITLE
Single thread build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,10 @@ const nextConfig = withPlausibleProxy()({
     locales: ['en', 'es'],
     defaultLocale: 'en',
   },
+  experimental: {
+    workerThreads: false,
+    cpus: 1
+  }
 });
 
 module.exports = nextConfig;


### PR DESCRIPTION
# Description

In order to prevent issues of multiple concurrent requests to Github hitting the rate limit, this PR uses an experimental feature of Next.js to use a single thread.

# Summary of changes:

- Experimental `workerThreads` set to false and CPUs to 1

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.