### PR TITLE
refactor: use 'main' branch for solana developer course

### DIFF
--- a/src/utils/fetch-course.ts
+++ b/src/utils/fetch-course.ts
@@ -1,7 +1,7 @@
 import { CourseStructure, Translations } from '../lib/types';
 import { get } from 'fetch-unfucked';
 
-const BRANCH: 'main' | 'draft' = 'draft';
+const BRANCH: 'main' | 'draft' = 'main';
 
 export const fetchLessonText = async (slug: string, locale?: string): Promise<string> => {
   const url = `https://raw.githubusercontent.com/Unboxed-Software/solana-course/${BRANCH}/content${


### PR DESCRIPTION
# Description

We (James Unboxed and I) decided to move the Solana Developer Course to the `main` branch now. The courses `CONTRIBUTING` no longer instructs people to clone `draft` and `main` is now up to date with draft.
 

# Summary of changes:

Just changes solana development course branch to `main`

# Checklist

- [x] I have performed a self-review of my own code.
- [N/A] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.