### PR TITLE
Translations

### DIFF
--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -39,7 +39,7 @@ export async function getStaticProps({ locale }: StaticProps) {
   };
 }
 
-export default function Page({ CourseStructure: CourseStructure, courseTranslations }: PageProps) {
+export default function Page({ CourseStructure, courseTranslations }: PageProps) {
   return (
     <DefaultLayout seo={seo}>
       <PageHero className="container space-y-3 text-center">

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -80,17 +80,17 @@ export default function Page({ CourseStructure, courseTranslations }: PageProps)
       <section className="container max-w-4xl">
         {CourseStructure.tracks.map((track, trackIndex) => (
           <Fragment key={trackIndex}>
-            <h2 className="text-4xl">{courseTranslations[track.slug]}</h2>
+            <h2 className="text-4xl">{courseTranslations[track.slug] || track.title} </h2>
             {track.units.map((unit, unitIndex) => (
               <Unit
                 key={unitIndex}
                 moduleNumber={unitIndex + 1}
-                title={courseTranslations[unit.slug]}
+                title={courseTranslations[unit.slug] || unit.title}
               >
                 {unit.lessons.map((lesson, lessonIndex) => (
                   <Lesson
                     key={lessonIndex}
-                    title={courseTranslations[lesson.slug]}
+                    title={courseTranslations[lesson.slug] || lesson.title}
                     href={`/course/${lesson.slug}`}
                     lessonNumber={lessonIndex + 1}
                     lab={lesson?.lab}

--- a/src/utils/fetch-course.ts
+++ b/src/utils/fetch-course.ts
@@ -1,7 +1,7 @@
 import { CourseStructure, Translations } from '../lib/types';
 import { get } from 'fetch-unfucked';
 
-const BRANCH: 'main' | 'draft' = 'main';
+const BRANCH: string = 'main';
 
 export const fetchLessonText = async (slug: string, locale?: string): Promise<string> => {
   const url = `https://raw.githubusercontent.com/Unboxed-Software/solana-course/${BRANCH}/content${


### PR DESCRIPTION
- change translations to fall back to the title if a translation for the slug is not available
- Remove reference to 'draft' for solana-course it's not used anymore
- Minor code tightening