### PR TITLE
Add Support for French Content

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,7 +15,7 @@ const nextConfig = withPlausibleProxy()({
     ],
   },
   i18n: {
-    locales: ['en', 'es'],
+    locales: ['en', 'es', 'fr'],
     defaultLocale: 'en',
   },
   experimental: {

--- a/src/components/core/LanguagePicker.tsx
+++ b/src/components/core/LanguagePicker.tsx
@@ -12,6 +12,10 @@ const LOCALES = {
   es: {
     title: 'Spanish',
     icon: '🇪🇸'
+  },
+  fr: {
+    title: 'French',
+    icon: '🇫🇷'
   }
 };
 
@@ -55,6 +59,7 @@ export default function LanguagePicker() {
           <div>
             <LocaleItem locale="en" />
             <LocaleItem locale="es" />
+            <LocaleItem locale="fr" />
           </div>
         </Menu.Items>
       </Transition>


### PR DESCRIPTION
# Description

This pull request adds support for French content to the Course. It aims to cater to the French-speaking audience in preparation for upcoming YouTube courses supporting Superteam FRANCE endeavours.

# Summary of changes:

- Integration of language selection functionality.
- Update of NextJS i18n configuration.

# Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] Existing unit tests pass locally with my changes.
